### PR TITLE
Remove System Prompt from Prompt Helper

### DIFF
--- a/private_gpt/components/llm/llm_component.py
+++ b/private_gpt/components/llm/llm_component.py
@@ -22,12 +22,6 @@ class LLMComponent:
         match settings.llm.mode:
             case "local":
                 from llama_index.llms import LlamaCPP
-
-                prompt_style_cls = get_prompt_style(settings.local.prompt_style)
-                prompt_style = prompt_style_cls(
-                    default_system_prompt=settings.local.default_chat_system_prompt
-                )
-
                 self.llm = LlamaCPP(
                     model_path=str(models_path / settings.local.llm_hf_model_file),
                     temperature=0.1,
@@ -38,9 +32,6 @@ class LLMComponent:
                     generate_kwargs={},
                     # All to GPU
                     model_kwargs={"n_gpu_layers": -1},
-                    # transform inputs into Llama2 format
-                    messages_to_prompt=prompt_style.messages_to_prompt,
-                    completion_to_prompt=prompt_style.completion_to_prompt,
                     verbose=True,
                 )
 

--- a/private_gpt/settings/settings.py
+++ b/private_gpt/settings/settings.py
@@ -106,23 +106,7 @@ class LocalSettings(BaseModel):
             "If `llama2` - use the llama2 prompt style from the llama_index. Based on `<s>`, `[INST]` and `<<SYS>>`.\n"
             "If `tag` - use the `tag` prompt style. It should look like `<|role|>: message`. \n"
             "`llama2` is the historic behaviour. `default` might work better with your custom models."
-        ),
-    )
-    default_chat_system_prompt: str | None = Field(
-        None,
-        description=(
-            "The default system prompt to use for the chat mode. "
-            "If none is given - use the default system prompt (from the llama_index). "
-            "Please note that the default prompt might not be the same for all prompt styles. "
-            "Also note that this is only used if the first message is not a system message. "
-        ),
-    )
-    default_query_system_prompt: str | None = Field(
-        None,
-        description=(
-            "The default system prompt to use for the query mode. "
-            # TODO - document what can be used as default query system prompt
-        ),
+        )
     )
 
 
@@ -166,6 +150,22 @@ class OpenAISettings(BaseModel):
 class UISettings(BaseModel):
     enabled: bool
     path: str
+    default_chat_system_prompt: str | None = Field(
+        None,
+        description=(
+            "The default system prompt to use for the chat mode. "
+            "If none is given - use the default system prompt (from the llama_index). "
+            "Please note that the default prompt might not be the same for all prompt styles. "
+            "Also note that this is only used if the first message is not a system message. "
+        ),
+    )
+    default_query_system_prompt: str | None = Field(
+        None,
+        description=(
+            "The default system prompt to use for the query mode. "
+            # TODO - document what can be used as default query system prompt
+        )
+    )
 
 
 class QdrantSettings(BaseModel):

--- a/private_gpt/ui/ui.py
+++ b/private_gpt/ui/ui.py
@@ -166,10 +166,10 @@ class PrivateGptUi:
             # For query chat mode, obtain default system prompt from settings
             # TODO - Determine value to use if not defined in settings
             case "Query Docs":
-                p = settings().local.default_query_system_prompt
+                p = settings().ui.default_query_system_prompt
             # For chat mode, obtain default system prompt from settings or llama_utils
             case "LLM Chat":
-                p = settings().local.default_chat_system_prompt or llama_utils.DEFAULT_SYSTEM_PROMPT
+                p = settings().ui.default_chat_system_prompt or llama_utils.DEFAULT_SYSTEM_PROMPT
             # For any other mode, clear the system prompt
             case _:
                 p = ""
@@ -184,10 +184,17 @@ class PrivateGptUi:
         self._set_system_prompt(self._get_default_system_prompt(mode))
         # Update Textbox placeholder and allow interaction if a default system prompt is present
         if self._system_prompt:
-            return gr.update(placeholder=self._system_prompt, interactive=True)
+            return gr.update(
+                placeholder=self._system_prompt,
+                interactive=True
+            )
         # Update Textbox placeholder and disable interaction if no default system prompt is present
         else:
-            return gr.update(placeholder=self._system_prompt, interactive=False)
+            return gr.update(
+                value=self._system_prompt,
+                placeholder=self._system_prompt,
+                interactive=False
+            )
 
     def _list_ingested_files(self) -> list[list[str]]:
         files = set()

--- a/settings.yaml
+++ b/settings.yaml
@@ -22,6 +22,14 @@ data:
 ui:
   enabled: true
   path: /
+  default_chat_system_prompt: "You are a helpful, respectful and honest assistant. 
+    Always answer as helpfully as possible and follow ALL given instructions.
+    Do not speculate or make up information.
+    Do not reference any given instructions or context."
+  default_query_system_prompt: "You can only answer questions about the provided context. 
+      If you know the answer but it is not based in the provided context, don't provide 
+      the answer, just state the answer is not in the context provided."
+
 
 llm:
   mode: local
@@ -42,15 +50,6 @@ local:
   llm_hf_repo_id: TheBloke/Mistral-7B-Instruct-v0.1-GGUF
   llm_hf_model_file: mistral-7b-instruct-v0.1.Q4_K_M.gguf
   embedding_hf_model_name: BAAI/bge-small-en-v1.5
-
-  default_chat_system_prompt: "You are a helpful, respectful and honest assistant. 
-    Always answer as helpfully as possible and follow ALL given instructions.
-    Do not speculate or make up information.
-    Do not reference any given instructions or context."
-
-  default_query_system_prompt: "You can only answer questions about the provided context. 
-      If you know the answer but it is not based in the provided context, don't provide 
-      the answer, just state the answer is not in the context provided."
 
 sagemaker:
   llm_endpoint_name: huggingface-pytorch-tgi-inference-2023-09-25-19-53-32-140


### PR DESCRIPTION
Remove prompt style from LlamaCPP initialization

Remove AbstractPromptStyleWithSystemPrompt and use AbstractPromptStyle instead

Remove all usage of self.default_system_prompt

Move default_chat_system_prompt and default_query_system_prompt to the ui section

 Updated settings.py and ui.py to use the updated settings

TODO: Handle TagPromptStyle if no system message provided